### PR TITLE
Support more non-additive statistics. Add Composer support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/Config/Memcache.php

--- a/Library/Data/Analysis.php
+++ b/Library/Data/Analysis.php
@@ -23,6 +23,14 @@
  */
 class Library_Data_Analysis
 {
+    const NON_ADDITIVE = [
+        'libevent',
+        'pid',
+        'pointer_size',
+        'time',
+        'uptime',
+        'version',
+    ];
 
     /**
      * Merge two arrays of stats from Command_XX::stats()
@@ -43,10 +51,10 @@ class Library_Data_Analysis
 
         # Merging Stats
         foreach ($stats as $key => $value) {
-            if (isset($array[$key]) && ($key != 'version') && ($key != 'uptime')) {
-                $array[$key] += $value;
-            } else {
+            if (! isset($array[$key]) || in_array($key, static::NON_ADDITIVE)) {
                 $array[$key] = $value;
+            } else {
+                $array[$key] += $value;
             }
         }
         return $array;
@@ -71,7 +79,7 @@ class Library_Data_Analysis
 
         # Diff for each key
         foreach ($stats as $key => $value) {
-            if (isset($array[$key])) {
+            if (isset($array[$key]) && ! in_array($key, static::NON_ADDITIVE)) {
                 $stats[$key] = $value - $array[$key];
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "elijaa/phpmemcacheadmin",
+    "description": "Graphic stand-alone administration for memcached",
+    "type": "library",
+    "license": "Apache-2.0",
+    "authors": [
+        {
+            "name": "Cyrille Mahieux",
+            "email": "elijaa@free.fr"
+        }
+    ],
+    "require": {}
+}


### PR DESCRIPTION
The current master version performs statistics merging by only special-casing "uptime" and "version" from additions, but there are more statistics in current memcache extension builds which can are not additive either, like "time" or 'libevent", and with the stricter warnings available in PHP 7.1, these cause warnings.

This PR extracts the non-additive list to a constant and uses it both for the main screen and live stats where similar errors occur when diffing non-additive statistics.