### PR TITLE
Issue #43: PHP 7.2 support

### DIFF
--- a/Library/Bootstrap.php
+++ b/Library/Bootstrap.php
@@ -17,10 +17,11 @@ foreach ($_REQUEST as $index => $data) {
 }
 
 # Autoloader
-function __autoload($class)
+function autoloader($class)
 {
     require_once str_replace('_', DIRECTORY_SEPARATOR, $class) . '.php';
 }
+spl_autoload_register('autoloader');
 
 # Loading ini file
 $_ini = Library_Configuration_Loader::singleton();


### PR DESCRIPTION
Replace the use of deprecated __autoload by spl_autoload_register, which has been recommended since PHP 5.1.0 in 2005.