### PR TITLE
Fix for missing mem_requested key

### DIFF
--- a/Library/Data/Analysis.php
+++ b/Library/Data/Analysis.php
@@ -219,6 +219,9 @@ class Library_Data_Analysis
                 if ($slab['used_chunks'] > 0) {
                     $slabs['used_slabs'] ++;
                 }
+                
+                if ( !array_key_exists('mem_requested', $slab) ) $slab['mem_requested'] = 0;
+                
                 $slabs[$id]['request_rate'] = sprintf('%.1f', ($slab['get_hits'] + $slab['cmd_set'] + $slab['delete_hits'] + $slab['cas_hits'] + $slab['cas_badval'] + $slab['incr_hits'] + $slab['decr_hits']) / $slabs['uptime'], 1);
                 $slabs[$id]['mem_wasted'] = (($slab['total_chunks'] * $slab['chunk_size']) < $slab['mem_requested']) ? (($slab['total_chunks'] - $slab['used_chunks']) * $slab['chunk_size']) : (($slab['total_chunks'] * $slab['chunk_size']) - $slab['mem_requested']);
                 $slabs['total_wasted'] += $slabs[$id]['mem_wasted'];


### PR DESCRIPTION
Without this the following apprears in the log: PHP Notice:  Undefined index: mem_requested in /var/www/xxx.xxx.xxx/htdocs/phpmemcachedadmin/Library/Data/Analysis.php on line 223

PHP v7.3.9 and memcached v1.5.18, pecl-memcached v3.1.3